### PR TITLE
Updating Keymap for Windows/Linux

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Install the module with: `apm install compare-files`
 2. Invoke the command using any of the below:
   1. From Command Palette (<kbd>⌘</kbd>+<kbd>⌂</kbd>+<kbd>P</kbd>) invoke `Compare Files: Compare`
   2. Right click on one of the selected files and choose `Compare Files`
-  3. Use the keyboard shortcut - <kbd>⌘</kbd>+<kbd>⌃</kbd>+<kbd>C</kbd>
+  3. Use the keyboard shortcut - <kbd>⌘</kbd>+<kbd>ctrl</kbd>+<kbd>C</kbd> (Windows and Linux: <kbd>ctrl</kbd>+<kbd>alt</kbd>+<kbd>C</kbd>)
 
 
 ![Screencast](http://i.imgur.com/1VBTGTy.gif)

--- a/keymaps/keymap.cson
+++ b/keymaps/keymap.cson
@@ -1,2 +1,10 @@
-'.atom-workspace':
+# keymaps for OSX
+'.platform-darwin .workspace':
   'cmd-ctrl-c': 'compare-files:compare'
+
+# commands for windows and Linux due to their lack of an cmd key
+'.platform-win32 .workspace':
+  'ctrl-alt-c': 'compare-files:compare'
+
+'.platform-linux .workspace':
+  'ctrl-alt-c': 'compare-files:compare'


### PR DESCRIPTION
Windows and Linux do not have a cmd key, so I added a separate key-mapping that will affect Windows/Linux machines, and updated the readme accordingly.