### PR TITLE
Promise handling through then instead of done

### DIFF
--- a/lib/compare-files.js
+++ b/lib/compare-files.js
@@ -78,7 +78,7 @@ var compare = function () {
 
       atom.workspace.
           open(uri, { searchAllPanes : true }).
-          done(function (compareFilesView) {
+          then(function (compareFilesView) {
             if (compareFilesView instanceof CompareFilesView) {
               _.delay(function () {
                 compareFilesView.renderDiffContent();


### PR DESCRIPTION
Insanely minor change to get rid of deprecation notice in Atom for Promise handling.